### PR TITLE
Support for openstack CLI command objects (Ready)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,41 +35,151 @@ Ensure `stack` user and group is absent. Included by ``devstack.clean`` state.
 
 Remove devstack - run unstack, clean, remove users and directories.
 
+``devstack.cli``
+------------------
+
+Support for the OpenStack CLI (OSC) documentaed at https://docs.openstack.org/python-openstackclient/queens/cli/. Meta state including ``cli.create``, ``cli.delete``, and ``cli.set`` states.
+
+``devstack.cli.create``
+-----------------------
+
+Support for the OpenStack CLI (OSC) create use cases.
+
+``devstack.cli.delete``
+-----------------------
+
+Support for the OpenStack CLI (OSC) delete use cases.
+
+``devstack.cli.set``
+-----------------------
+
+Support for the OpenStack CLI (OSC) set use cases.
+
+
 Testing
 =========
 Verified on Fedora 27, Ubuntu 16.04, and Centos 7.
 
-Reference Configuration
+Reference Solution
 ========================
-The following configuration was needed on Fedora 27. On Ubuntu the `packages` state was unnecesary.
+The following configuration seems to work fine on RedHat family and Ubuntu. For OpenStack CLI (OSC) suppport, study the ``pillar.example`` carefully and raise an issue to track failed OSC commands.
 
-State top file::
+Salt states top file (top.sls)::
 
         base:
           '*':
-            - packages                #we are missing mysql.removed state, needed on Fedora27
-            - mysql                   #install mysql server
+            - packages          #See we are missing mysql.removed state, needed on Fedora27
+            - mysql             #install mysql server
             - devstack.clean
             - devstack
+            - devstack.cli      #See https://docs.openstack.org/python-openstackclient/queens/cli/
 
-Pillar Data::
-        
+Devstack Pillar Data (see pillar.example)::
+
         devstack:
+            {% set servicename = 'serviceX' %}
+            {% set service_version = 'v0.2.0' %}
+            {% set host_ip = '127.0.0.1' %}
+            {% set svc_tcpport = '50040' %}
+            {% set password = 'devstack' %}
+            {% set servicetype = servicename %}
+            {% set endpointname = servicename ~ service_version %}
+
           local:
             username: stack
-            password: devstack
-            enabled_services: 'mysql,key'     #needs quotes
-            ### used by devstack openrc
-            os_password: devstack
-        
+            password: {{ password }}
+            enabled_services: 'mysql,key'
+            os_password: {{ password }}
+            host_ip: {{ host_ip }}
+            host_ipv6: {{ grains.ipv6[-1] }}
+            service_host: {{ host_ip }}
+
+          cli:
+            user:
+              create:
+                {{ servicename }}:
+                  options:
+                    domain: default
+                    password: {{ password }}
+                    project: service
+                    enable: True
+              delete:
+                demo:
+                  options:
+                    domain: default
+                alt_demo:
+                  options:
+                    domain: default
+            group:
+              create:
+                service:
+                  options:
+                    domain: default
+              add user:
+                service:
+                  target:
+                    - {{ servicename }}
+                admins:
+                  options:
+                    domain: default
+                  target:
+                    - admin
+            role:
+              add:
+                admin:
+                  options:
+                    project: service
+                    user: {{ servicename }}
+                service:
+                  options:
+                    project: service
+                    group: service
+            service:
+              create:
+                {{ servicetype }}:
+                  options:
+                    name: {{ servicename }}
+                    type: identity
+                    description: OpenSDS Block Storage
+                    enable: True
+            endpoint:
+              create:
+                '{{ endpointname }} public https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+                  options:
+                    region: RegionOne
+                    enable: True
+                '{{ endpointname }} internal https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+                  options:
+                    region: RegionOne
+                    enable: True
+                '{{ endpointname }} admin https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+                  options:
+                    region: RegionOne
+                    enable: True
+            project:
+              delete:
+                demo:
+                  options:
+                    domain: default
+                alt_demo:
+                  options:
+                    domain: default
+                invisible_to_admin:
+                  options:
+                    domain: default
+
+
+Supporting Stack Pillar Data::
+
         mysql:
-          # mysql password needs to match devstack 'DATABASE_PASSWORD'
+          # mysql password needs to match devstack 'DATABASE_PASSWORD' !!!!!!!!! Important !!!!
           server:
             root_password: 'devstack'
         
         packages:
           pkgs:
             #Needed because of https://github.com/saltstack-formulas/mysql-formula/issues/195
+            #Used on RedHat family anyway!
             unwanted:
               - mariadb
               - mariadb-tokudb-engine

--- a/README.rst
+++ b/README.rst
@@ -64,31 +64,38 @@ Reference Solution
 ========================
 The following configuration seems to work fine on RedHat family and Ubuntu. For OpenStack CLI (OSC) suppport, study the ``pillar.example`` carefully and raise an issue to track failed OSC commands.
 
-Salt states top file (top.sls)::
+Salt states (top.sls) for install::
 
         base:
           '*':
-            - packages          #See we are missing mysql.removed state, needed on Fedora27
-            - mysql             #install mysql server
+            - packages          #RedHat only? https://github.com/saltstack-formulas/mysql-formula/issues/195
+            - mysql             #install mysql server (after ``packages`` state runs)
             - devstack.clean
             - devstack
+
+Salt states (top.sls) for Openstack CLI::
+
+        base:
+          '*':
             - devstack.cli      #See https://docs.openstack.org/python-openstackclient/queens/cli/
 
-Devstack Pillar Data (see pillar.example)::
+
+Site/Release-specific Pillar Data (see pillar.example)::
 
         devstack:
-            {% set servicename = 'serviceX' %}
+            {% set yourservicename = 'myKeyStone' %}
+            {% set enabled_services = 'mysql,key' %}
             {% set service_version = 'v0.2.0' %}
             {% set host_ip = '127.0.0.1' %}
             {% set svc_tcpport = '50040' %}
             {% set password = 'devstack' %}
-            {% set servicetype = servicename %}
-            {% set endpointname = servicename ~ service_version %}
+            {% set servicetype = yourservicename %}
+            {% set endpointname = yourservicename ~ service_version %}
 
           local:
             username: stack
             password: {{ password }}
-            enabled_services: 'mysql,key'
+            enabled_services: {{ enabled_services }}
             os_password: {{ password }}
             host_ip: {{ host_ip }}
             host_ipv6: {{ grains.ipv6[-1] }}
@@ -97,7 +104,7 @@ Devstack Pillar Data (see pillar.example)::
           cli:
             user:
               create:
-                {{ servicename }}:
+                {{ yourservicename }}:
                   options:
                     domain: default
                     password: {{ password }}
@@ -118,7 +125,7 @@ Devstack Pillar Data (see pillar.example)::
               add user:
                 service:
                   target:
-                    - {{ servicename }}
+                    - {{ yourservicename }}
                 admins:
                   options:
                     domain: default
@@ -129,7 +136,7 @@ Devstack Pillar Data (see pillar.example)::
                 admin:
                   options:
                     project: service
-                    user: {{ servicename }}
+                    user: {{ yourservicename }}
                 service:
                   options:
                     project: service
@@ -138,9 +145,9 @@ Devstack Pillar Data (see pillar.example)::
               create:
                 {{ servicetype }}:
                   options:
-                    name: {{ servicename }}
+                    name: {{ yourservicename }}
                     type: identity
-                    description: OpenSDS Block Storage
+                    description: {{ yourservicename }} Service
                     enable: True
             endpoint:
               create:

--- a/devstack/clean.sls
+++ b/devstack/clean.sls
@@ -35,6 +35,16 @@ openstack-devstack clean:
   {%- endif %}
 
 openstack-devstack cleandown:
+  user.absent:
+    - name: {{ devstack.local.username }}
+    - purge: True
+  cmd.run:
+    - name: userdel -f -r {{ devstack.local.username }}
+    - onlyif: getent passwd {{ devstack.local.username }}
+    - onfail:
+      - user: openstack-devstack cleandown
+  group.absent:
+    - name: {{ devstack.local.username }}
   file.absent:
     - names:
       - {{ devstack.dir.dest }}

--- a/devstack/cli/create.sls
+++ b/devstack/cli/create.sls
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "devstack/map.jinja" import devstack with context %}
+{% from "devstack/files/macros.jinja" import nameopt, getcmd, getopts, getlist with context %}
+
+    {% for feature, task in devstack.cli.items() %}
+      {%- if "create" in devstack.cli[feature] and devstack.cli[feature]['create'] is mapping %}
+        {% for item, itemdata in devstack.cli[feature]['create'].items() %}
+
+devstack_{{ feature }}_create_{{ item }}:
+  cmd.run:
+    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} create {{ getcmd(itemdata) }} {{ item }}
+    - onlyif: openstack {{ feature }} show {{ item }} 2>/dev/null
+    - runas: {{ devstack.local.username }}
+    - env:
+      - DEV_STACK_DIR: {{ devstack.dir.dest }}
+
+        {% endfor %}
+      {%- endif %}
+    {% endfor %}

--- a/devstack/cli/create.sls
+++ b/devstack/cli/create.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 {% from "devstack/map.jinja" import devstack with context %}
-{% from "devstack/files/macros.jinja" import nameopt, getcmd, getopts, getlist with context %}
+{% from "devstack/files/macros.jinja" import getcmd, getopts, getlist with context %}
 
     {% for feature, task in devstack.cli.items() %}
       {%- if "create" in devstack.cli[feature] and devstack.cli[feature]['create'] is mapping %}

--- a/devstack/cli/delete.sls
+++ b/devstack/cli/delete.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 {% from "devstack/map.jinja" import devstack with context %}
-{% from "devstack/files/macros.jinja" import nameopt, getcmd, getopts, getlist with context %}
+{% from "devstack/files/macros.jinja" import getcmd, getopts, getlist with context %}
 
     {% for feature, task in devstack.cli.items() %}
       {%- if "delete" in devstack.cli[feature] and devstack.cli[feature]['delete'] is mapping %}

--- a/devstack/cli/delete.sls
+++ b/devstack/cli/delete.sls
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "devstack/map.jinja" import devstack with context %}
+{% from "devstack/files/macros.jinja" import nameopt, getcmd, getopts, getlist with context %}
+
+    {% for feature, task in devstack.cli.items() %}
+      {%- if "delete" in devstack.cli[feature] and devstack.cli[feature]['delete'] is mapping %}
+        {% for item, itemdata in devstack.cli[feature]['delete'].items() %}
+
+devstack_{{ feature }}_delete_{{ item }}:
+  cmd.run:
+    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} delete {{ getcmd(itemdata) }} {{ item }}
+    - onlyif: openstack {{ feature }} show {{ item }} 2>/dev/null
+    - runas: {{ devstack.local.username }}
+    - env:
+      - DEV_STACK_DIR: {{ devstack.dir.dest }}
+
+        {% endfor %}
+      {%- endif %}
+    {% endfor %}

--- a/devstack/cli/init.sls
+++ b/devstack/cli/init.sls
@@ -1,0 +1,6 @@
+## Automate tasks in logical sequence ...
+
+include:
+  - .delete
+  - .set
+  - .create

--- a/devstack/cli/set.sls
+++ b/devstack/cli/set.sls
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "devstack/map.jinja" import devstack with context %}
+{% from "devstack/files/macros.jinja" import nameopt, getcmd, getopts, getlist with context %}
+
+    {% for feature, task in devstack.cli.items() %}
+      {%- if "set" in devstack.cli[feature] and devstack.cli[feature]['set'] is mapping %}
+        {% for item, itemdata in devstack.cli[feature]['set'].items() %}
+
+devstack_{{ feature }}_set_{{ item }}:
+  cmd.run:
+    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} set {{ getcmd(itemdata) }} {{ item }}
+    - onlyif: openstack {{ feature }} show {{ item }} 2>/dev/null
+    - runas: {{ devstack.local.username }}
+    - env:
+      - DEV_STACK_DIR: {{ devstack.dir.dest }}
+
+        {% endfor %}
+      {%- endif %}
+    {% endfor %}

--- a/devstack/cli/set.sls
+++ b/devstack/cli/set.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 {% from "devstack/map.jinja" import devstack with context %}
-{% from "devstack/files/macros.jinja" import nameopt, getcmd, getopts, getlist with context %}
+{% from "devstack/files/macros.jinja" import getcmd, getopts, getlist with context %}
 
     {% for feature, task in devstack.cli.items() %}
       {%- if "set" in devstack.cli[feature] and devstack.cli[feature]['set'] is mapping %}

--- a/devstack/defaults.yaml
+++ b/devstack/defaults.yaml
@@ -4,6 +4,7 @@ devstack:
   mode: '0644'
   pkgs: ['git','bridge-utils',]
   pips: []
+  cli: {}
   dir:
     dest: /opt/stack
     home: /home

--- a/devstack/files/macros.jinja
+++ b/devstack/files/macros.jinja
@@ -1,0 +1,23 @@
+{%- macro getcmd(outdict) -%}
+  {%- for key, value in outdict.items() -%}
+    {{- getargs(key, value) -}}
+  {%- endfor -%} 
+{%- endmacro -%}
+
+{%- macro getargs(k, v) %}
+  {%- if v is mapping %}
+    {{- getcmd(v) -}}
+  {%- elif v is string or v is number %}
+      {{ ' --' ~ k if v == True else '' if v == False else ' --' ~ k ~ ' ' ~ v  }}
+  {%- elif v is iterable and v is not string -%}
+      {{- getlist(v) -}}
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- macro getlist(mylist) -%}
+  {%- if mylist and mylist is iterable and mylist is not string -%}
+    {%- for v in mylist -%}
+      {{ ' ' ~ v }}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endmacro -%}

--- a/pillar.example
+++ b/pillar.example
@@ -1,12 +1,13 @@
 #SITE & RELEASE SPECIFIC DATA
 
-    {% set servicename = 'serviceX' %}
+    {% set yourservicename = 'KeyService' %}
+    {% set enabled_services = 'mysql,key' %}
     {% set service_version = 'v0.2.0' %}
     {% set host_ip = '127.0.0.1' %}
     {% set svc_tcpport = '50040' %}
     {% set password = 'devstack' %}
-    {% set servicetype = servicename %}
-    {% set endpointname = servicename ~ service_version %}
+    {% set servicetype = yourservicename %}
+    {% set endpointname = yourservicename ~ service_version %}
 
 
 #DATA DICTIONARY
@@ -15,7 +16,7 @@ devstack:
   local:
     username: stack
     password: {{ password }}
-    enabled_services: 'mysql,key'
+    enabled_services: {{ enabled_services }}
     os_password: {{ password }}
     host_ip: {{ host_ip }}
     host_ipv6: {{ grains.ipv6[-1] }}
@@ -24,7 +25,7 @@ devstack:
   cli:
     user:
       create:
-        {{ servicename }}:
+        {{ yourservicename }}:
           options:
             domain: default
             password: {{ password }}
@@ -45,7 +46,7 @@ devstack:
       add user:
         service:
           target:
-            - {{ servicename }}
+            - {{ yourservicename }}
         admins:
           options:
             domain: default
@@ -56,7 +57,7 @@ devstack:
         admin:
           options:
             project: service
-            user: {{ servicename }}
+            user: {{ yourservicename }}
         service:
           options:
             project: service
@@ -65,9 +66,9 @@ devstack:
       create:
         {{ servicetype }}:
           options:
-            name: {{ servicename }}
+            name: {{ yourservicename }}
             type: identity
-            description: OpenSDS Block Storage
+            description: {{ yourservicename }} Service
             enable: True
     endpoint:
       create:

--- a/pillar.example
+++ b/pillar.example
@@ -1,33 +1,97 @@
-#Minimal pillars might be
+#SITE & RELEASE SPECIFIC DATA
+
+    {% set servicename = 'serviceX' %}
+    {% set service_version = 'v0.2.0' %}
+    {% set host_ip = '127.0.0.1' %}
+    {% set svc_tcpport = '50040' %}
+    {% set password = 'devstack' %}
+    {% set servicetype = servicename %}
+    {% set endpointname = servicename ~ service_version %}
+
+
+#DATA DICTIONARY
+
 devstack:
   local:
     username: stack
-    password: devstack
-    enabled_services: 'mysql,key'     #needs quotes
-    ### used by devstack openrc
-    os_password: devstack
+    password: {{ password }}
+    enabled_services: 'mysql,key'
+    os_password: {{ password }}
+    host_ip: {{ host_ip }}
+    host_ipv6: {{ grains.ipv6[-1] }}
+    service_host: {{ host_ip }}
 
-#Other custom pillars include ..
-    reclone: yes
-    git_base: 'https://git.example.org'
-    git_branch: stable/pike
-    git_url: 'https://git.example.org/openstack-dev/devstack'
-    host_name: host1.example.com
-    enable_httpd_mod_wsgi_services: True
-    keystone_use_mod_wsgi: True
-    logfile: really_long_filename_stack.sh.log
-    logdays: 1000000
-    verbose: True
-    enable_debug_log_level: True
-    ### used by devstack openrc ###
-    os_password: soggydew
-    service_host: 127.0.0.1
-    host_ip: 127.0.0.1
-    host_ipv6: 127.0.0.1
-    odl_mgr_ip: 127.0.0.1
+  cli:
+    user:
+      create:
+        {{ servicename }}:
+          options:
+            domain: default
+            password: {{ password }}
+            project: service
+            enable: True
+      delete:
+        demo:
+          options:
+            domain: default
+        alt_demo:
+          options:
+            domain: default
+    group:
+      create:
+        service:
+          options:
+            domain: default
+      add user:
+        service:
+          target:
+            - {{ servicename }}
+        admins:
+          options:
+            domain: default
+          target:
+            - admin
+    role:
+      add:
+        admin:
+          options:
+            project: service
+            user: {{ servicename }}
+        service:
+          options:
+            project: service
+            group: service
+    service:
+      create:
+        {{ servicetype }}:
+          options:
+            name: {{ servicename }}
+            type: identity
+            description: OpenSDS Block Storage
+            enable: True
+    endpoint:
+      create:
+        '{{ endpointname }} public https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+          options:
+            region: RegionOne
+            enable: True
+        '{{ endpointname }} internal https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+          options:
+            region: RegionOne
+            enable: True
+        '{{ endpointname }} admin https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+          options:
+            region: RegionOne
+            enable: True
+    project:
+      delete:
+        demo:
+          options:
+            domain: default
+        alt_demo:
+          options:
+            domain: default
+        invisible_to_admin:
+          options:
+            domain: default
 
- dir:
-    dest: /opt/home/stack         # Setting /home/<user>/ triggers stack.sh failure (0700 permissions)
-    log: /tmp/stackyyy            # Setting /tmp/ triggers unstack.sh ('rm -f /tmp') bug
-    config: /opt/home/stack/local.conf
-    sudoers_file: /etc/sudoers.d/50_devstack_user


### PR DESCRIPTION
This PR proposes to add full support for [OSC]( https://docs.openstack.org/python-openstackclient/queens/cli/) via four states:

- devstack.cli  (meta state)
- devstack.cli.delete (delete objects)
- devstack.cli.set (set object attributes)
- devstack.cli.create (create objects).

To support DRY principle, `delete`, `set`, `create` states could be merged into `init.sls` (for loop) but the granularity is important to support running states in any sequence.

WIP as I have no time to test right now.