### PR TITLE
remove 'unless' condition to ensure group add/rm works

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,16 @@ Available states
 
 Deploy devstack using `stack.sh` and custom `localrc` generated from pillar data.
 
+``devstack.user``
+------------------
+
+Ensure `stack` user and group exists. Included by ``devstack`` state.
+
+``devstack.user.remove``
+------------------
+
+Ensure `stack` user and group is absent. Included by ``devstack.clean`` state.
+
 ``devstack.remove``
 ------------------
 

--- a/devstack/clean.sls
+++ b/devstack/clean.sls
@@ -32,7 +32,6 @@ openstack-devstack cleandown:
   user.absent:
     - name: {{ devstack.local.username }}
     - purge: True
-    - onlyif: getent passwd {{ devstack.local.username }}
   cmd.run:
     - name: userdel -f {{ devstack.local.username }}
     - onlyif: getent passwd {{ devstack.local.username }}
@@ -40,7 +39,6 @@ openstack-devstack cleandown:
       - user: openstack-devstack cleandown
   group.absent:
     - name: {{ devstack.local.username }}
-    - onlyif: getent group {{ devstack.local.username }}
   file.absent:
     - names:
       - {{ devstack.dir.dest }}
@@ -48,4 +46,3 @@ openstack-devstack cleandown:
       - {{ devstack.local.sudoers_file }}
     - require:
       - cmd: openstack-devstack cleandown
-      # group: openstack-devstack cleandown

--- a/devstack/clean.sls
+++ b/devstack/clean.sls
@@ -2,6 +2,10 @@
 # vim: ft=sls
 {% from "devstack/map.jinja" import devstack with context %}
 
+# user/group are not deleted until this state runs!
+include:
+  - .user.remove
+
   {%- if salt['cmd.run']('getent passwd ' ~ devstack.local.username, output_loglevel='quiet') %}
 
 openstack-devstack unstack:
@@ -13,7 +17,8 @@ openstack-devstack unstack:
     - runas: {{ devstack.local.username }}
     - onlyif: test -f {{ devstack.local.sudoers_file }} && getent passwd {{ devstack.local.username }}
     - require_in:
-      - user: openstack-devstack cleandown
+      - file: openstack-devstack cleandown
+      - user: openstack-devstack ensure user and group absent
 
 openstack-devstack clean:
   cmd.run:
@@ -24,25 +29,16 @@ openstack-devstack clean:
     - runas: {{ devstack.local.username }}
     - onlyif: test -f {{ devstack.local.sudoers_file }} && getent passwd {{ devstack.local.username }}
     - require_in:
-      - user: openstack-devstack cleandown
+      - file: openstack-devstack cleandown
+      - user: openstack-devstack ensure user and group absent
 
   {%- endif %}
 
 openstack-devstack cleandown:
-  user.absent:
-    - name: {{ devstack.local.username }}
-    - purge: True
-  cmd.run:
-    - name: userdel -f {{ devstack.local.username }}
-    - onlyif: getent passwd {{ devstack.local.username }}
-    - onfail:
-      - user: openstack-devstack cleandown
-  group.absent:
-    - name: {{ devstack.local.username }}
   file.absent:
     - names:
       - {{ devstack.dir.dest }}
       - {{ devstack.dir.log }}/logs
       - {{ devstack.local.sudoers_file }}
     - require:
-      - cmd: openstack-devstack cleandown
+      - user: openstack-devstack ensure user and group absent

--- a/devstack/init.sls
+++ b/devstack/init.sls
@@ -2,30 +2,16 @@
 # vim: ft=sls
 {% from "devstack/map.jinja" import devstack with context %}
 
+# user/group are created before this state runs
+include:
+  - .user
+
 openstack-devstack ensure package dependencies:
   pkg.installed:
     - names:
       {%- for pkg in devstack.pkgs %}
       - {{ pkg }}
       {%- endfor %}
-
-openstack-devstack ensure user and group exist:
-  group.present:
-    - name: {{ devstack.local.username }}
-  user.present:
-    - name: {{ devstack.local.username }}
-    - fullname: DevStack User
-    - shell: /bin/bash
-    - home: {{ devstack.dir.dest }}
-    - createhome: True
-    - groups:
-      - {{ devstack.local.username }}
-    - require:
-      - group: openstack-devstack ensure user and group exist
-    - require_in:
-      - file: openstack-devstack ensure user and group exist
-      - file: openstack-devstack configure local_conf and run stack
-      - git: openstack-devstack git cloned and sudo access
   file.directory:
     - name: {{ devstack.dir.dest }}
     - dir_mode: '0755'
@@ -39,6 +25,7 @@ openstack-devstack git cloned and sudo access:
     - user: {{ devstack.local.username }}
     - force_clone: True
     - require:
+      - user: - user: openstack-devstack ensure user and group present
       - pkg: openstack-devstack ensure package dependencies
   file.managed:
     - name: {{ devstack.local.sudoers_file }}

--- a/devstack/init.sls
+++ b/devstack/init.sls
@@ -12,7 +12,6 @@ openstack-devstack ensure package dependencies:
 openstack-devstack ensure user and group exist:
   group.present:
     - name: {{ devstack.local.username }}
-    - unless: getent group {{ devstack.local.username }}
   user.present:
     - name: {{ devstack.local.username }}
     - fullname: DevStack User
@@ -27,7 +26,6 @@ openstack-devstack ensure user and group exist:
       - file: openstack-devstack ensure user and group exist
       - file: openstack-devstack configure local_conf and run stack
       - git: openstack-devstack git cloned and sudo access
-    - unless: getent passwd {{ devstack.local.username }}
   file.directory:
     - name: {{ devstack.dir.dest }}
     - dir_mode: '0755'

--- a/devstack/user/init.sls
+++ b/devstack/user/init.sls
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "devstack/map.jinja" import devstack with context %}
+
+openstack-devstack ensure user and group exist:
+  group.present:
+    - name: {{ devstack.local.username }}
+  user.present:
+    - name: {{ devstack.local.username }}
+    - fullname: DevStack User
+    - shell: /bin/bash
+    - home: {{ devstack.dir.dest }}
+    - createhome: True
+    - groups:
+      - {{ devstack.local.username }}
+    - require:
+      - group: openstack-devstack ensure user and group exist

--- a/devstack/user/remove.sls
+++ b/devstack/user/remove.sls
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "devstack/map.jinja" import devstack with context %}
+
+openstack-devstack ensure user and group absent:
+  user.absent:
+    - name: {{ devstack.local.username }}
+    - force: True
+    - purge: True
+  cmd.run:
+    - name: userdel -f {{ devstack.local.username }}
+    - onlyif: getent passwd {{ devstack.local.username }}
+    - onfail:
+      - user: openstack-devstack cleandown
+  group.absent:
+    - name: {{ devstack.local.username }}
+    - require:
+      - cmd: openstack-devstack ensure user and group absent


### PR DESCRIPTION
Fix this unexpected issue on Fedora27 when Active Directory is used
```
----------
          ID: openstack-devstack cleandown
    Function: group.absent
        Name: stack
      Result: False
     Comment: Failed to remove group stack
     Started: 19:36:30.167747
    Duration: 50.518 ms
     Changes:   


          ID: openstack-devstack ensure user and group exist
    Function: group.present
        Name: stack
      Result: True
     Comment: unless execution succeeded
     Started: 19:36:30.245230
    Duration: 31.529 ms
     Changes:   
----------
          ID: openstack-devstack ensure user and group exist
    Function: user.present
        Name: stack
      Result: False
     Comment: The following group(s) are not present: stack
     Started: 19:36:30.283611
    Duration: 242.782 ms
     Changes:

```
