### PR TITLE
Fix cli.create conditional bug; update docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,13 +105,13 @@ Site/Release-specific Pillar Data (see pillar.example)::
             {% set devstack_password = 'devstack' %}
             {% set devstack_svc_type = devstack_svc_name %}
             {% set devstack_svc_endpoint = devstack_svc_name ~ devstack_svc_version %}
-            {% set host_ip = grains.ip[-1] or '127.0.0.1' %}
+            {% set host_ip = grains.ipv4[-1] or '127.0.0.1' %}
             {% set host_ipv6 = grains.ipv6[-1] %}
         devstack:
           local:
             username: stack
             password: {{ devstack_password }}
-            devstack_enabled_services: {{ devstack_enabled_services }}
+            enabled_services: {{ devstack_enabled_services }}
             os_password: {{ devstack_password }}
             host_ip: {{ host_ip }}
             host_ipv6: {{ host_ipv6 }}
@@ -166,15 +166,15 @@ Site/Release-specific Pillar Data (see pillar.example)::
                     enable: True
             endpoint:
               create:
-                '{{ devstack_svc_endpoint }} public https://{{ host_ip or host_ip6 }}/{{ devstack_svc_port }}/{{ devstack_svc_version }}/%\(tenant_id\)s':
+                '{{ devstack_svc_endpoint }} public https://{{ host_ip or host_ipv6 }}/{{ devstack_svc_port }}/{{ devstack_svc_version }}/%\(tenant_id\)s':
                   options:
                     region: RegionOne
                     enable: True
-                '{{ devstack_svc_endpoint }} internal https://{{ host_ip or host_ip6 }}/{{ devstack_svc_port }}/{{ devstack_svc_version }}/%\(tenant_id\)s':
+                '{{ devstack_svc_endpoint }} internal https://{{ host_ip or host_ipv6 }}/{{ devstack_svc_port }}/{{ devstack_svc_version }}/%\(tenant_id\)s':
                   options:
                     region: RegionOne
                     enable: True
-                '{{ devstack_svc_endpoint }} admin https://{{ host_ip or host_ip6 }}/{{ devstack_svc_port }}/{{ devstack_svc_version }}/%\(tenant_id\)s':
+                '{{ devstack_svc_endpoint }} admin https://{{ host_ip or host_ipv6 }}/{{ devstack_svc_port }}/{{ devstack_svc_version }}/%\(tenant_id\)s':
                   options:
                     region: RegionOne
                     enable: True

--- a/devstack/cli/create.sls
+++ b/devstack/cli/create.sls
@@ -10,7 +10,7 @@
 devstack_{{ feature }}_create_{{ item }}:
   cmd.run:
     - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} create {{ getcmd(itemdata) }} {{ item }}
-    - onlyif: openstack {{ feature }} show {{ item }} 2>/dev/null
+    - unless: openstack {{ feature }} show {{ item }} 2>/dev/null
     - runas: {{ devstack.local.username }}
     - env:
       - DEV_STACK_DIR: {{ devstack.dir.dest }}

--- a/devstack/defaults.yaml
+++ b/devstack/defaults.yaml
@@ -40,9 +40,10 @@ devstack:
     neutron_branch:
     swift_branch:
     glance_branch:
-    ### used by devstack openrc ###
+
+    ### needed by devstack openrc ###
     os_password: devstack
-    host_ip:
-    host_ipv6:
-    service_host:
-    odl_mgr_ip:
+    host_ip: {{ grains.ip[-1] }}
+    host_ipv6: {{ grains.ip6[-1] }}
+    service_host: {{ grains.ip[-1] or grains.ipv6[-1] }}
+    odl_mgr_ip: {{ grains.ip[-1] or grains.ipv6[-1] }}

--- a/devstack/defaults.yaml
+++ b/devstack/defaults.yaml
@@ -43,7 +43,7 @@ devstack:
 
     ### needed by devstack openrc ###
     os_password: devstack
-    host_ip: {{ grains.ip[-1] }}
-    host_ipv6: {{ grains.ip6[-1] }}
-    service_host: {{ grains.ip[-1] or grains.ipv6[-1] }}
-    odl_mgr_ip: {{ grains.ip[-1] or grains.ipv6[-1] }}
+    host_ip: {{ grains.ipv4[-1] }}
+    host_ipv6: {{ grains.ipv6[-1] }}
+    service_host: {{ grains.ipv4[-1] or grains.ipv6[-1] }}
+    odl_mgr_ip: {{ grains.ipv4[-1] or grains.ipv6[-1] }}

--- a/pillar.example
+++ b/pillar.example
@@ -7,7 +7,7 @@
     {% set devstack_password = 'devstack' %}
     {% set devstack_yoursvc_type = devstack_yoursvc_name %}
     {% set devstack_yoursvc_endpoint = devstack_yoursvc_name ~ devstack_yoursvc_version %}
-    {% set host_ip = grains.ip[-1] or '127.0.0.1' %}
+    {% set host_ip = grains.ipv4[-1] or '127.0.0.1' %}
     {% set host_ipv6 = grains.ipv6[-1] %}
 
 
@@ -17,7 +17,7 @@ devstack:
   local:
     username: stack
     password: {{ devstack_password }}
-    devstack_enabled_services: {{ devstack_enabled_services }}
+    enabled_services: {{ devstack_enabled_services }}
     os_password: {{ devstack_password }}
     host_ip: {{ host_ip }}
     host_ipv6: {{ host_ipv6 }}
@@ -73,15 +73,15 @@ devstack:
             enable: True
     endpoint:
       create:
-        '{{ devstack_yoursvc_endpoint }} public https://{{ host_ip or host_ip6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
+        '{{ devstack_yoursvc_endpoint }} public https://{{ host_ip or host_ipv6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
           options:
             region: RegionOne
             enable: True
-        '{{ devstack_yoursvc_endpoint }} internal https://{{ host_ip or host_ip6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
+        '{{ devstack_yoursvc_endpoint }} internal https://{{ host_ip or host_ipv6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
           options:
             region: RegionOne
             enable: True
-        '{{ devstack_yoursvc_endpoint }} admin https://{{ host_ip or host_ip6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
+        '{{ devstack_yoursvc_endpoint }} admin https://{{ host_ip or host_ipv6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
           options:
             region: RegionOne
             enable: True

--- a/pillar.example
+++ b/pillar.example
@@ -1,13 +1,14 @@
 #SITE & RELEASE SPECIFIC DATA
 
-    {% set yourservicename = 'KeyService' %}
-    {% set enabled_services = 'mysql,key' %}
-    {% set service_version = 'v0.2.0' %}
-    {% set host_ip = '127.0.0.1' %}
-    {% set svc_tcpport = '50040' %}
-    {% set password = 'devstack' %}
-    {% set servicetype = yourservicename %}
-    {% set endpointname = yourservicename ~ service_version %}
+    {% set devstack_yoursvc_name = 'Keystone' %}
+    {% set devstack_enabled_services = 'mysql,key' %}
+    {% set devstack_yoursvc_version = 'v0.2.0' %}
+    {% set devstack_yoursvc_port = '50040' %}
+    {% set devstack_password = 'devstack' %}
+    {% set devstack_yoursvc_type = devstack_yoursvc_name %}
+    {% set devstack_yoursvc_endpoint = devstack_yoursvc_name ~ devstack_yoursvc_version %}
+    {% set host_ip = grains.ip[-1] or '127.0.0.1' %}
+    {% set host_ipv6 = grains.ipv6[-1] %}
 
 
 #DATA DICTIONARY
@@ -15,20 +16,20 @@
 devstack:
   local:
     username: stack
-    password: {{ password }}
-    enabled_services: {{ enabled_services }}
-    os_password: {{ password }}
+    password: {{ devstack_password }}
+    devstack_enabled_services: {{ devstack_enabled_services }}
+    os_password: {{ devstack_password }}
     host_ip: {{ host_ip }}
-    host_ipv6: {{ grains.ipv6[-1] }}
-    service_host: {{ host_ip }}
+    host_ipv6: {{ host_ipv6 }}
+    service_host: {{ host_ip or host_ipv6 }}
 
   cli:
     user:
       create:
-        {{ yourservicename }}:
+        {{ devstack_yoursvc_name }}:
           options:
             domain: default
-            password: {{ password }}
+            password: {{ devstack_password }}
             project: service
             enable: True
       delete:
@@ -46,7 +47,7 @@ devstack:
       add user:
         service:
           target:
-            - {{ yourservicename }}
+            - {{ devstack_yoursvc_name }}
         admins:
           options:
             domain: default
@@ -57,30 +58,30 @@ devstack:
         admin:
           options:
             project: service
-            user: {{ yourservicename }}
+            user: {{ devstack_yoursvc_name }}
         service:
           options:
             project: service
             group: service
     service:
       create:
-        {{ servicetype }}:
+        {{ devstack_yoursvc_type }}:
           options:
-            name: {{ yourservicename }}
+            name: {{ devstack_yoursvc_name }}
             type: identity
-            description: {{ yourservicename }} Service
+            description: {{ devstack_yoursvc_name }} Service
             enable: True
     endpoint:
       create:
-        '{{ endpointname }} public https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+        '{{ devstack_yoursvc_endpoint }} public https://{{ host_ip or host_ip6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
           options:
             region: RegionOne
             enable: True
-        '{{ endpointname }} internal https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+        '{{ devstack_yoursvc_endpoint }} internal https://{{ host_ip or host_ip6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
           options:
             region: RegionOne
             enable: True
-        '{{ endpointname }} admin https://{{ host_ip }}/{{ svc_tcpport }}/{{ service_version }}/%\(tenant_id\)s':
+        '{{ devstack_yoursvc_endpoint }} admin https://{{ host_ip or host_ip6 }}/{{ devstack_yoursvc_port }}/{{ devstack_yoursvc_version }}/%\(tenant_id\)s':
           options:
             region: RegionOne
             enable: True


### PR DESCRIPTION
This PR is for two reasons.   Firstly there is a bug in `cli.state` create where `onlyif` is used instead of `unless` - this was missed during cut+paste during editing.   The second thing  I would like is to ensure variables in pillar.example and README use `devstack_` prefix to help avoid Jinja variable name collision. This is minor update to the formula. Thanks.