### PR TITLE
Fix create problem caused by unordered dict

### DIFF
--- a/devstack/cli/create.sls
+++ b/devstack/cli/create.sls
@@ -3,18 +3,38 @@
 {% from "devstack/map.jinja" import devstack with context %}
 {% from "devstack/files/macros.jinja" import getcmd, getopts, getlist with context %}
 
-    {% for feature, task in devstack.cli.items() %}
+    {%- for feature, task in devstack.cli.items() %}
       {%- if "create" in devstack.cli[feature] and devstack.cli[feature]['create'] is mapping %}
-        {% for item, itemdata in devstack.cli[feature]['create'].items() %}
+         {%- if feature in ['user', 'group', 'role', 'service',] %} 
+             {%- for item, itemdata in devstack.cli[feature]['create'].items() %}
 
-devstack_{{ feature }}_create_{{ item }}:
+devstack_{{ feature }}_create_prerequisite_{{ item }}:
   cmd.run:
-    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} create {{ getcmd(itemdata) }} {{ item }}
+    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} create {{- getcmd(itemdata) -}} {{ item }}
     - unless: openstack {{ feature }} show {{ item }} 2>/dev/null
     - runas: {{ devstack.local.username }}
     - env:
       - DEV_STACK_DIR: {{ devstack.dir.dest }}
 
-        {% endfor %}
+              {%- endfor %}
+          {%- endif %}
       {%- endif %}
-    {% endfor %}
+    {%- endfor %}
+
+    {%- for feature, task in devstack.cli.items() %}
+      {%- if "create" in devstack.cli[feature] and devstack.cli[feature]['create'] is mapping %}
+         {%- if feature not in ['user', 'group', 'role', 'service',] %} 
+            {%- for item, itemdata in devstack.cli[feature]['create'].items() %}
+
+devstack_{{ feature }}_create_remaining_{{ item }}:
+  cmd.run:
+    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} create {{- getcmd(itemdata) -}} {{ item }}
+    - unless: openstack {{ feature }} show {{ item }} 2>/dev/null
+    - runas: {{ devstack.local.username }}
+    - env:
+      - DEV_STACK_DIR: {{ devstack.dir.dest }}
+
+            {%- endfor %}
+         {%- endif %}
+      {%- endif %}
+    {%- endfor %}

--- a/devstack/cli/delete.sls
+++ b/devstack/cli/delete.sls
@@ -9,7 +9,7 @@
 
 devstack_{{ feature }}_delete_{{ item }}:
   cmd.run:
-    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} delete {{ getcmd(itemdata) }} {{ item }}
+    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} delete {{- getcmd(itemdata) -}} {{ item }}
     - onlyif: openstack {{ feature }} show {{ item }} 2>/dev/null
     - runas: {{ devstack.local.username }}
     - env:

--- a/devstack/cli/set.sls
+++ b/devstack/cli/set.sls
@@ -9,7 +9,7 @@
 
 devstack_{{ feature }}_set_{{ item }}:
   cmd.run:
-    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} set {{ getcmd(itemdata) }} {{ item }}
+    - name: source ${DEV_STACK_DIR}/openrc admin admin && openstack {{ feature }} set {{- getcmd(itemdata) -}} {{ item }}
     - onlyif: openstack {{ feature }} show {{ item }} 2>/dev/null
     - runas: {{ devstack.local.username }}
     - env:

--- a/devstack/defaults.yaml
+++ b/devstack/defaults.yaml
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 devstack:
+  hide_output: True
+  dir_mode: '0755'
   mode: '0644'
   pkgs: ['git','bridge-utils',]
   pips: []

--- a/devstack/files/macros.jinja
+++ b/devstack/files/macros.jinja
@@ -8,7 +8,7 @@
   {%- if v is mapping %}
     {{- getcmd(v) -}}
   {%- elif v is string or v is number %}
-      {{ ' --' ~ k if v == True else '' if v == False else ' --' ~ k ~ ' ' ~ v  }}
+      {{- ' --' ~ k ~ ' ' if v == True else '' if v == False else ' --' ~ k ~ ' "' ~ v ~ '" ' -}}
   {%- elif v is iterable and v is not string -%}
       {{- getlist(v) -}}
   {%- endif -%}
@@ -17,7 +17,7 @@
 {%- macro getlist(mylist) -%}
   {%- if mylist and mylist is iterable and mylist is not string -%}
     {%- for v in mylist -%}
-      {{ ' ' ~ v }}
+      {{- ' "' ~ v ~ '" ' -}}
     {%- endfor -%}
   {%- endif -%}
 {%- endmacro -%}

--- a/devstack/install.sls
+++ b/devstack/install.sls
@@ -58,6 +58,7 @@ openstack-devstack configure local_conf and run stack:
     - names:
       - chown -R {{ devstack.local.username }}:{{ devstack.local.username }} {{ devstack.dir.dest }}
       - {{ devstack.dir.dest }}/stack.sh
+    - hide_output: {{ devstack.hide_output }}
     - env:
       - HOST_IP: {{ grains.ipv4[-1] if not devstack.local.host_ip else devstack.local.host_ip }}
       - HOST_IPV6: {{ grains.ipv6[-1] if not devstack.local.host_ipv6 else devstack.local.host_ipv6 }}

--- a/devstack/user/init.sls
+++ b/devstack/user/init.sls
@@ -15,3 +15,12 @@ openstack-devstack ensure user and group exist:
       - {{ devstack.local.username }}
     - require:
       - group: openstack-devstack ensure user and group exist
+  file.directory:
+    - name: {{ devstack.dir.dest }}
+    - user: {{ devstack.local.username }}
+    - dir_mode: {{ devstack.dir_mode }}
+    - group: {{ devstack.local.username }}
+    - recurse:
+      - user
+      - group
+      - mode

--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,7 @@
 #DATA DICTIONARY
 
 devstack:
+  hide_output: False    #view output from stack.sh
   local:
     username: stack
     password: {{ devstack_password }}


### PR DESCRIPTION
This PR fixes a sequencing problem with `devstack.cli.create` state.

Because python dict is unordered, the order of pillar data is not respected.  Therefore `endpoint` can, and often does, get created before its dependent `service` - **this causes failed states.**

As solution I split create state into two for loops ...

1. create **prereq objects first**.

`         {%- if feature in ['user', 'group', 'role', 'service',] %} .    ... etc ...`

2. create **other objects last***
`         {%- if feature not in ['user', 'group', 'role', 'service',] %}`

Verified on Ubuntu and Centos.