### PR TITLE
Ensure /tmp/devstack is writeable

### DIFF
--- a/devstack/clean.sls
+++ b/devstack/clean.sls
@@ -8,6 +8,12 @@ include:
 
   {%- if salt['cmd.run']('getent passwd ' ~ devstack.local.username, output_loglevel='quiet') %}
 
+openstack-devstack check permissions:
+  cmd.run:
+    - name: chown -R {{devstack.local.username}}:{{devstack.local.username}} {{devstack.dir.dest}} {{devstack.dir.tmp}}/devstack
+    - require_in:
+      - cmd: openstack-devstack unstack
+
 openstack-devstack unstack:
   cmd.run:
     - name: sudo {{ devstack.dir.dest }}/unstack.sh | true

--- a/devstack/install.sls
+++ b/devstack/install.sls
@@ -51,7 +51,7 @@ openstack-devstack configure local_conf:
         dir:  {{ devstack.dir|json }}
   cmd.run:
     - names:
-      - chown -R {{devstack.local.username}}:{{devstack.local.username}} {{devstack.dir.dest}}
+      - chown -R {{devstack.local.username}}:{{devstack.local.username}} {{devstack.dir.dest}} {{devstack.dir.tmp}}/devstack
 
 openstack-devstack run stack:
   cmd.run:


### PR DESCRIPTION
This PR ensures `stack.sh` and `unstack.sh` can write to /tmp/devstack 
```
IOError: [Errno 13] Permission denied: '/tmp/devstack/stack.sh.log.2018-12-01-230013'
[ERROR   ] retcode: 1
```