### PR TITLE
Reinstall python-pip after stack.sh uninstalls

### DIFF
--- a/devstack/defaults.yaml
+++ b/devstack/defaults.yaml
@@ -2,12 +2,15 @@
 # vim: ft=yaml
 devstack:
   hide_output: True
-  dir_mode: '0755'
+  dir_mode: '0775'
   mode: '0644'
   pkgs: ['git','bridge-utils',]
   pips: []
+  pip_pkg: python-pip
   cli: {}
+
   dir:
+    tmp: /tmp
     dest: /opt/stack
     log: /tmp/devstack
   local:

--- a/devstack/osmap.yaml
+++ b/devstack/osmap.yaml
@@ -1,4 +1,8 @@
 
-Centos:
+CentOS:
   pkgs:
     - epel-release
+  pip_pkg: python2-pip
+
+FreeBSD:
+  pip_pkg: devel/py-pip

--- a/devstack/user/init.sls
+++ b/devstack/user/init.sls
@@ -16,10 +16,13 @@ openstack-devstack ensure user and group exist:
     - require:
       - group: openstack-devstack ensure user and group exist
   file.directory:
-    - name: {{ devstack.dir.dest }}/.cache
+    - names:
+      - {{ devstack.dir.dest }}/.cache
+      - {{ devstack.dir.dest }}
+      - {{ devstack.dir.tmp }}
     - user: {{ devstack.local.username }}
-    - dir_mode: {{ devstack.dir_mode }}
     - group: {{ devstack.local.username }}
+    - dir_mode: {{ devstack.dir_mode }}
     - recurse:
       - user
       - group


### PR DESCRIPTION
Devstack removes `python-pip` by default.  This PR keeps default behaviour but adds  `devstack.disable_install_pip` boolean pillar to stop removal of `/usr/bin/pip` (hack).


```
local:
----------
          ID: docker-packages-cleaned-service-dead
    Function: service.dead
        Name: docker
      Result: True
     Comment: The named service docker is not available
     Started: 09:17:00.424238
    Duration: 483.845 ms
     Changes:   
----------
          ID: docker-packages-cleaned
    Function: pkg.removed
      Result: True
     Comment: All specified packages are already absent
     Started: 09:17:00.915437
    Duration: 329.556 ms
     Changes:   
----------
          ID: docker-pips-removed
    Function: pip.removed
        Name: docker-compose
      Result: True
     Comment: onlyif condition is false
     Started: 09:17:01.245226
    Duration: 18.232 ms
     Changes:   

Summary for local
------------
Succeeded: 3
Failed:    0
------------
```