### PR TITLE
Add MYSQL_HOST var and minor updates

### DIFF
--- a/devstack/defaults.yaml
+++ b/devstack/defaults.yaml
@@ -9,6 +9,7 @@ devstack:
   cli: {}
   dir:
     dest: /opt/stack
+    tmp: /tmp
     log: /tmp/devstack
   local:
     enabled_services:

--- a/devstack/files/local.conf.j2
+++ b/devstack/files/local.conf.j2
@@ -1,8 +1,17 @@
+#!/bin/bash
 ####################
 ## Managed by Salt
 #####################
 
 [[local|localrc]]
+HOST_IP=${HOST_IP:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
+HOST_IPV6=${HOST_IPV6:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
+HOST_NAME={{ grains.host if not data.host_name else data.host_name }}
+SERVICE_HOST=${SERVICE_HOST:-$HOST_IP}
+MYSQL_HOST=${MYSQL_HOST:-$HOST_IP}
+RABBIT_HOST=${RABBIT_HOST:-$HOST_IP}
+GLANCE_HOSTPORT=${GLANCE_HOSTPORT:-$HOST_IP:9292}
+
 ENABLED_SERVICES={{ data.enabled_services or "" }}
 DEST=${DEST:-{{ "/opt/stack" if not dir.dest else dir.dest }}}
 DATA_DIR=${DATA_DIR:-{{ '/opt/stack' if not dir.dest else dir.dest }}/data}
@@ -11,29 +20,20 @@ GIT_BASE=${GIT_BASE:-{{ "https://git.openstack.org" if not data.git_base else da
 GIT_BRANCH=${GIT_BRANCH:-{{ "master" if not data.git_branch else data.git_branch }}}
 RECLONE={{ data.reclone or "no" }}
 
-SERVICE_HOST=${HOST_IP:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
-ODL_MGR_IP=${HOST_IP:-{{ grains.ipv4[-1] if not data.odl_mgr_ip else data.odl_mgr_ip }}}
-HOST_NAME={{ grains.host if not data.host_name else data.host_name }}
-
-VERBOSE={{ data.verbose or "" }}
-ENABLE_DEBUG_LOG_LEVEL={{ data.enable_debug_log_level or "" }}
-ENABLE_VERBOSE_LOG_LEVEL={{ data.enable_verbose_log_level or "" }}
-
 # If the ``*_PASSWORD`` variables are not set here you will be prompted to enter ..
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-{{ data.admin_password or data.password or "nomoresecret" }}}
 SERVICE_PASSWORD=${ADMIN_PASSWORD}
 DATABASE_PASSWORD=${DATABASE_PASSWORD:-{{ data.database_password or data.password or "stackdb" }}}
 RABBIT_PASSWORD=${RABBIT_PASSWORD:-{{ data.rabbit_password or data.password or "stackqueue" }}}
-SERVICE_PASSWORD=$ADMIN_PASSWORD
+SERVICE_PASSWORD=${ADMIN_PASSWORD}
 SERVICE_TOKEN=${SERVICE_TOKEN:-{{ data.service_token or data.password or "nomoresecret" }}}
-
-# ``HOST_IP`` and ``HOST_IPV6`` should be set manually .. Neither is set by default.
-HOST_IP=${HOST_IP:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
-HOST_IPV6=${HOST_IPV6:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
 
 # Logging
 # -------
-LOGFILE={{ dir.log or "$DEST/logs" }}/{{ data.logfile }}
+LOGFILE={{ dir.log or "${DEST}/logs" }}/{{ data.logfile }}
+VERBOSE={{ data.verbose or "" }}
+ENABLE_DEBUG_LOG_LEVEL={{ data.enable_debug_log_level or "" }}
+ENABLE_VERBOSE_LOG_LEVEL={{ data.enable_verbose_log_level or "" }}
 
 # Old log files are automatically removed after 7 days to keep things neat.  Change
 # the number of days by setting ``LOGDAYS``.
@@ -56,12 +56,28 @@ SWIFT_BRANCH=${SWIFT_BRANCH:-{{ data.swift_branch or data.git_branch }}}
 
 # Swift
 # -----
-SWIFT_HASH=66a3d6b56c1f479c8b4e70ab5c2000f5
+SWIFT_HASH='66a3d6b56c1f479c8b4e70ab5c2000f5'
 # For development purposes the default of 3 replicas is usually not required.
-SWIFT_REPLICAS=1
+SWIFT_REPLICAS='1'
+
+## Neutron
+# -----
+Q_USE_SECGROUP=${Q_USE_SECGROUP:-True}
+FLOATING_RANGE=${FLOATING_RANGE:-}
+IPV4_ADDRS_SAFE_TO_USE=${IPV4_ADDRS_SAFE_TO_USE:-}
+Q_FLOATING_ALLOCATION_POOL=${Q_FLOATING_ALLOCATION_POOL:-}
+PUBLIC_NETWORK_GATEWAY=${PUBLIC_NETWORK_GATEWAY:-{{ grains.ip4_gw or grains.ipv6_gw }}}
+PUBLIC_INTERFACE=${PUBLIC_INTERFACE:-}
+
+# Open vSwitch provider networking configuration
+Q_USE_PROVIDERNET_FOR_PUBLIC=${Q_USE_PROVIDERNET_FOR_PUBLIC:-True}
+OVS_PHYSICAL_BRIDGE=${OVS_PHYSICAL_BRIDGE:-br-ex}
+PUBLIC_BRIDGE=${OVS_PHYSICAL_BRIDGE:-br-ex}
+OVS_BRIDGE_MAPPINGS=${OVS_BRIDGE_MAPPINGS:-public:br-ex}
+
+ODL_MGR_IP=${HOST_IP:-{{ grains.ipv4[-1] if not data.odl_mgr_ip else data.odl_mgr_ip }}}
 
 # Used by openrc
 #---------------
 # Ref: https://docs.openstack.org/devstack/latest/configuration.html#local-conf
-
 OS_PASSWORD=${OS_PASSWORD:{{ data.os_password or "$ADMIN_PASSWORD" }}}

--- a/devstack/files/stackrc.j2
+++ b/devstack/files/stackrc.j2
@@ -5,6 +5,8 @@
 ####################
 ## Managed by Salt
 ####################
+HOST_IP=${HOST_IP:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
+HOST_IPV6=${HOST_IPV6:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
 
 # ensure we don't re-source this in the same environment
 [[ -z "$_DEVSTACK_STACKRC" ]] || return 0

--- a/devstack/install.sls
+++ b/devstack/install.sls
@@ -7,6 +7,15 @@ include:
   - .user
 
 openstack-devstack ensure package dependencies:
+  file.directory:
+    - name: {{ devstack.dir.tmp }}/devstack
+    - makedirs: True
+    - force: True
+    - user: {{ devstack.local.username or 'stack' }}
+    - dir_mode: '0755'
+    - recurse:
+      - user
+      - mode
   pkg.installed:
     - names:
       {%- for pkg in devstack.pkgs %}
@@ -58,7 +67,7 @@ openstack-devstack run stack:
     - name: {{ devstack.dir.dest }}/stack.sh
     - hide_output: {{ devstack.hide_output }}
     - env:
-      - HOST_IP: {{ grains.ipv4[-1] if not devstack.local.host_ip else devstack.local.host_ip }}
+      - HOST_IP: {{grains.ipv4[-1] if not devstack.local.host_ip else devstack.local.host_ip}}
       - HOST_IPV6: {{grains.ipv6[-1] if not devstack.local.host_ipv6 else devstack.local.host_ipv6}}
     - runas: {{ devstack.local.username }}
     - require:


### PR DESCRIPTION
This PR fixes a few issues. In particular the MYSQL_HOST variable should equal HOST_IP by default.

```
          ID: openstack-devstack run stack
    Function: cmd.run
        Name: /opt/opensds-linux-amd64-devstack/stack.sh
      Result: True
     Comment: Command "/opt/opensds-linux-amd64-devstack/stack.sh" run
     Started: 14:14:11.206601
    Duration: 114438.168 ms
     Changes:   
              ----------
              pid:
                  19812
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: devstack_group_create_prerequisite_service
    Function: cmd.run
        Name: source ~/openrc admin admin && openstack group create --domain "default" service
      Result: True
     Comment: Command "source ~/openrc admin admin && openstack group create --domain "default" service" run
     Started: 14:16:05.645005
    Duration: 1334.739 ms
     Changes:   
              ----------
              pid:
                  14754
              retcode:
                  0
              stderr:
              stdout:
                  WARNING: setting legacy OS_TENANT_NAME to support cli tools.
                  +-------------+----------------------------------+
                  | Field       | Value                            |
                  +-------------+----------------------------------+
                  | description |                                  |
                  | domain_id   | default                          |
                  | id          | 263ae05b9efe4a5a99edf1214be1424c |
                  | name        | service                          |
                  +-------------+----------------------------------+
----------
          ID: devstack_user_create_prerequisite_opensdsv0.3.3
    Function: cmd.run
        Name: source ~/openrc admin admin && openstack user create --domain "default"  --password "opensds@123"  --project "service"  --enable opensdsv0.3.3
      Result: True
     Comment: Command "source ~/openrc admin admin && openstack user create --domain "default"  --password "opensds@123"  --project "service"  --enable opensdsv0.3.3" run
     Started: 14:16:06.980044
    Duration: 1429.106 ms
     Changes:   
              ----------
              pid:
                  14904
              retcode:
                  0
              stderr:
              stdout:
                  WARNING: setting legacy OS_TENANT_NAME to support cli tools.
                  +---------------------+----------------------------------+
                  | Field               | Value                            |
                  +---------------------+----------------------------------+
                  | default_project_id  | 98a2406a5ee84e738bc583a96a13c44c |
                  | domain_id           | default                          |
                  | enabled             | True                             |
                  | id                  | 6ecbc56981d249bf86b0a9b1533b4845 |
                  | name                | opensdsv0.3.3                    |
                  | options             | {}                               |
                  | password_expires_at | None                             |
                  +---------------------+----------------------------------+
----------
          ID: devstack_service_create_prerequisite_opensdsv0.3.3
    Function: cmd.run
        Name: source ~/openrc admin admin && openstack service create --name "opensdsv0.3.3"  --description "opensds Service"  --enable opensdsv0.3.3
      Result: True
     Comment: Command "source ~/openrc admin admin && openstack service create --name "opensdsv0.3.3"  --description "opensds Service"  --enable opensdsv0.3.3" run
     Started: 14:16:08.409601
    Duration: 1271.173 ms
     Changes:   
              ----------
              pid:
                  15054
              retcode:
                  0
              stderr:
              stdout:
                  WARNING: setting legacy OS_TENANT_NAME to support cli tools.
                  +-------------+----------------------------------+
                  | Field       | Value                            |
                  +-------------+----------------------------------+
                  | description | opensds Service                  |
                  | enabled     | True                             |
                  | id          | 55846c04d8534497bba50540087faac4 |
                  | name        | opensdsv0.3.3                    |
                  | type        | opensdsv0.3.3                    |
                  +-------------+----------------------------------+
----------
          ID: devstack_endpoint_create_remaining_opensdsv0.3.3 public https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s
    Function: cmd.run
        Name: source ~/openrc admin admin && openstack endpoint create --region "RegionOne"  --enable opensdsv0.3.3 public https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s
      Result: True
     Comment: Command "source ~/openrc admin admin && openstack endpoint create --region "RegionOne"  --enable opensdsv0.3.3 public https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s" run
     Started: 14:16:09.681103
    Duration: 1338.291 ms
     Changes:   
              ----------
              pid:
                  15205
              retcode:
                  0
              stderr:
              stdout:
                  WARNING: setting legacy OS_TENANT_NAME to support cli tools.
                  +--------------+-------------------------------------------------+
                  | Field        | Value                                           |
                  +--------------+-------------------------------------------------+
                  | enabled      | True                                            |
                  | id           | f827ab703e6146f78d33c4436b9b5b85                |
                  | interface    | public                                          |
                  | region       | RegionOne                                       |
                  | region_id    | RegionOne                                       |
                  | service_id   | 55846c04d8534497bba50540087faac4                |
                  | service_name | opensdsv0.3.3                                   |
                  | service_type | opensdsv0.3.3                                   |
                  | url          | https://192.168.1.12/50040/v0.3.3/%(tenant_id)s |
                  +--------------+-------------------------------------------------+
----------
          ID: devstack_endpoint_create_remaining_opensdsv0.3.3 internal https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s
    Function: cmd.run
        Name: source ~/openrc admin admin && openstack endpoint create --region "RegionOne"  --enable opensdsv0.3.3 internal https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s
      Result: True
     Comment: Command "source ~/openrc admin admin && openstack endpoint create --region "RegionOne"  --enable opensdsv0.3.3 internal https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s" run
     Started: 14:16:11.019692
    Duration: 1337.221 ms
     Changes:   
              ----------
              pid:
                  15361
              retcode:
                  0
              stderr:
              stdout:
                  WARNING: setting legacy OS_TENANT_NAME to support cli tools.
                  +--------------+-------------------------------------------------+
                  | Field        | Value                                           |
                  +--------------+-------------------------------------------------+
                  | enabled      | True                                            |
                  | id           | 10cd08b34419418493c6dae299199825                |
                  | interface    | internal                                        |
                  | region       | RegionOne                                       |
                  | region_id    | RegionOne                                       |
                  | service_id   | 55846c04d8534497bba50540087faac4                |
                  | service_name | opensdsv0.3.3                                   |
                  | service_type | opensdsv0.3.3                                   |
                  | url          | https://192.168.1.12/50040/v0.3.3/%(tenant_id)s |
                  +--------------+-------------------------------------------------+
----------
          ID: devstack_endpoint_create_remaining_opensdsv0.3.3 admin https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s
    Function: cmd.run
        Name: source ~/openrc admin admin && openstack endpoint create --region "RegionOne"  --enable opensdsv0.3.3 admin https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s
      Result: True
     Comment: Command "source ~/openrc admin admin && openstack endpoint create --region "RegionOne"  --enable opensdsv0.3.3 admin https://192.168.1.12/50040/v0.3.3/%\(tenant_id\)s" run
     Started: 14:16:12.357270
    Duration: 1389.2 ms
     Changes:   
              ----------
              pid:
                  15526
              retcode:
                  0
              stderr:
              stdout:
                  WARNING: setting legacy OS_TENANT_NAME to support cli tools.
                  +--------------+-------------------------------------------------+
                  | Field        | Value                                           |
                  +--------------+-------------------------------------------------+
                  | enabled      | True                                            |
                  | id           | 7b056ce0ca7e4da0b4c24f8f5fa1aeff                |
                  | interface    | admin                                           |
                  | region       | RegionOne                                       |
                  | region_id    | RegionOne                                       |
                  | service_id   | 55846c04d8534497bba50540087faac4                |
                  | service_name | opensdsv0.3.3                                   |
                  | service_type | opensdsv0.3.3                                   |
                  | url          | https://192.168.1.12/50040/v0.3.3/%(tenant_id)s |
                  +--------------+-------------------------------------------------+

Summary for local
-------------
Succeeded: 18 (changed=10)
Failed:     0
-------------
Total states run:     18
Total run time:  130.244 s
```