### PR TITLE
devstack hardcodes 127.0.0.1 for mysql :-(

### DIFF
--- a/devstack/files/local.conf.j2
+++ b/devstack/files/local.conf.j2
@@ -8,7 +8,8 @@ HOST_IP=${HOST_IP:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
 HOST_IPV6=${HOST_IPV6:-{{ grains.ipv4[-1] if not data.host_ip else data.host_ip }}}
 HOST_NAME={{ grains.host if not data.host_name else data.host_name }}
 SERVICE_HOST=${SERVICE_HOST:-$HOST_IP}
-MYSQL_HOST=${MYSQL_HOST:-$HOST_IP}
+MYSQL_HOST=${MYSQL_HOST:-{{ data.db_host or '127.0.0.1' }}}
+DATABASE_HOST=${DATABASE_HOST:-{{ data.db_host or '127.0.0.1' }}}
 RABBIT_HOST=${RABBIT_HOST:-$HOST_IP}
 GLANCE_HOSTPORT=${GLANCE_HOSTPORT:-$HOST_IP:9292}
 

--- a/pillar.example
+++ b/pillar.example
@@ -8,6 +8,7 @@
     {% set devstack_yoursvc_type = devstack_yoursvc_name %}
     {% set devstack_yoursvc_endpoint = devstack_yoursvc_name ~ devstack_yoursvc_version %}
     {% set host_ip = grains.ipv4[-1] or '127.0.0.1' %}
+    {% set db_host = '127.0.0.1' %}  {# https://bugs.launchpad.net/devstack/+bug/1735097 #}
     {% set host_ipv6 = grains.ipv6[-1] %}
 
 


### PR DESCRIPTION
Workaround upstream [limitation](https://bugs.launchpad.net/devstack/+bug/1735097) where 127.0.0.1 is hardcoded in /opt/stack/lib/databases/mysql.