### PR TITLE
Use a different tempdir

### DIFF
--- a/devstack/defaults.yaml
+++ b/devstack/defaults.yaml
@@ -11,7 +11,7 @@ devstack:
 
   dir:
     dest: /opt/stack
-    tmp: /tmp
+    tmp: /tmp/devstack
     log: /tmp/devstack
   local:
     enabled_services:

--- a/devstack/user/init.sls
+++ b/devstack/user/init.sls
@@ -17,7 +17,6 @@ openstack-devstack ensure user and group exist:
       - group: openstack-devstack ensure user and group exist
   file.directory:
     - names:
-      - {{ devstack.dir.dest }}/.cache
       - {{ devstack.dir.dest }}
       - {{ devstack.dir.tmp }}
     - user: {{ devstack.local.username }}


### PR DESCRIPTION
Don't use /tmp for tempdir and no need for cache dir (already covered).