### PR TITLE
fix(freebsd): fix two issues

### DIFF
--- a/devstack/files/local.conf.j2
+++ b/devstack/files/local.conf.j2
@@ -66,7 +66,13 @@ Q_USE_SECGROUP=${Q_USE_SECGROUP:-True}
 FLOATING_RANGE=${FLOATING_RANGE:-}
 IPV4_ADDRS_SAFE_TO_USE=${IPV4_ADDRS_SAFE_TO_USE:-}
 Q_FLOATING_ALLOCATION_POOL=${Q_FLOATING_ALLOCATION_POOL:-}
+
+    {%- if "ip4_gw" in grains %}
 PUBLIC_NETWORK_GATEWAY=${PUBLIC_NETWORK_GATEWAY:-{{ grains.ip4_gw }}}
+    {%- elif grains.os_family == 'FreeBSD' %}
+        {%- set ip4_gw = salt['cmd.run']("netstat -r | grep ^default | awk '{print $2}'") %}
+PUBLIC_NETWORK_GATEWAY=${PUBLIC_NETWORK_GATEWAY:-{{ ip4_gw }}}
+    {%- endif %}
 PUBLIC_INTERFACE=${PUBLIC_INTERFACE:-}
 
 # Open vSwitch provider networking configuration

--- a/devstack/osfamilymap.yaml
+++ b/devstack/osfamilymap.yaml
@@ -12,3 +12,7 @@ Debian:
     - bridge-utils
     - apache2
     - python3-distutils
+
+FreeBSD:
+  pkgs:
+    - git


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

1. There is no package called bridge-utils on FreeBSD
However, no extra packages are needed to create a bridge interface on FreeBSD. See: https://www.freebsd.org/doc/handbook/network-bridging.html

This PR fixes this error
```
          ID: openstack devstack ensure package dependencies
    Function: pkg.installed
        Name: bridge-utils
      Result: False
     Comment: Problem encountered installing package(s). Additional info follows:

              errors:
                  - pkg: No packages available to install matching 'bridge-utils' 
                            have been found in the repositories
```
2. There is no `ip4_gw` grain on FreeBSD salt.
PR fixes this issue via jinja variable.
```
          ID: openstack devstack configure local_conf
    Function: file.managed
        Name: /opt/stack/local.conf
      Result: False
     Comment: Unable to manage file: Jinja variable 'dict object' has no attribute 'ip4_gw'
```
### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

```
[root@bazinga /usr/home/vagrant]# salt-call -V  --local
Salt Version:
           Salt: 2019.2.3
 
Dependency Versions:
           cffi: 1.14.0
       cherrypy: Not Installed
       dateutil: Not Installed
      docker-py: 4.2.0
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.10.1
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.6.2
   mysql-python: Not Installed
      pycparser: 2.19
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 2.7.17 (default, Mar 21 2020, 01:18:34)
   python-gnupg: Not Installed
         PyYAML: 5.2
          PyZMQ: 18.1.1
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.5.3
            ZMQ: 4.3.1
 
System Versions:
           dist:   
         locale: US-ASCII
        machine: amd64
        release: 11.3-RELEASE
         system: FreeBSD
        version: Not Installed
```

